### PR TITLE
fixed check in index_table.cpp to allow neg simple indices

### DIFF
--- a/src/sialx/test/loop_over_simple_indices.sialx
+++ b/src/sialx/test/loop_over_simple_indices.sialx
@@ -28,7 +28,7 @@ do dd
  print_index dd
 enddo dd
 
-println "should print e = [0,10]"
+println "should print ee = [0,10]"
 do ee
  print_index ee
 enddo ee

--- a/src/sip/static_data/index_table.cpp
+++ b/src/sip/static_data/index_table.cpp
@@ -186,8 +186,8 @@ void IndexTableEntry::init(const std::string& name, IndexTableEntry& entry,
 	entry.name_ = name;
 	entry.lower_seg_ = bseg;
 	entry.num_segments_ = (eseg - bseg) + 1;
-    sip::check(entry.lower_seg_ >= 0, "-ve value for lower_seg_");
-    sip::check(entry.num_segments_ >= 0, "-ve value for lower_seg_");
+    sip::check(entry.index_type_ == simple || entry.lower_seg_ >= 0, "-ve value for lower_seg_");
+    sip::check(entry.num_segments_ >= 0, "-ve value for num_segements_");
     
 	entry.index_type_ = intToIndexType_t(siox_file.read_int());
 	if (entry.index_type_ != subindex) { //set subindex_descriptor in IndexTable::init rather than here
@@ -198,23 +198,6 @@ void IndexTableEntry::init(const std::string& name, IndexTableEntry& entry,
 
 }
 
-//void IndexTableEntry::init_symbolic(sip::IntTable& intTable) {
-//	int bseg = lower_seg_;
-//	int eseg = num_segments_;  //num_segements_ was briefly set to eseg in init
-//	if (bseg <= 0) {  //this is a symbolic constant  TODO check == 0
-////		int int_table_index = (bseg<0? (-bseg) - 1 : 0); //the intTable uses C indexing
-//		int int_table_index = -bseg;
-//		bseg = intTable.value(int_table_index);
-//	}
-//	if (eseg <= 0) {
-////		int int_table_index = (eseg<0? (-eseg) - 1 : 0); //the intTable uses C indexing
-//		int int_table_index = -eseg;
-//		eseg = intTable.value(int_table_index);
-//	}
-//	lower_seg_ = bseg;
-//	num_segments_ = (eseg - bseg) + 1;  //now it is really the size
-//	assert(num_segments_ >= 0);
-//}
 
 std::ostream& operator<<(std::ostream& os, const IndexTableEntry &entry) {
 	os << entry.name_;


### PR DESCRIPTION
A test was added to index_table.cpp that fails if the lower bound (lower_seg_) is negative.
This caused one of the test_simple test cases to fail.  Since simple indices should
be allowed to have negative values, I changed the test to check if the index is simple before failing.

Is there some reason not to do this?
