### PR TITLE
Fix LRU problem of only using first block of array

### DIFF
--- a/src/sip/dynamic_data/lru_array_policy.h
+++ b/src/sip/dynamic_data/lru_array_policy.h
@@ -11,6 +11,7 @@
 #include "sip_interface.h"
 #include "id_block_map.h"
 #include "block_id.h"
+#include "server_block.h"
 
 #include <list>
 #include <stdexcept>
@@ -62,10 +63,14 @@ public:
 			int to_remove_array = lru_list_.back();
 			typename IdBlockMap<BLOCK_TYPE>::PerArrayMap* array_map = block_map_.per_array_map(to_remove_array);
 			typename IdBlockMap<BLOCK_TYPE>::PerArrayMap::iterator it = array_map->begin();
-			if (it == array_map->end())
-				lru_list_.pop_back();
-			else
-				return it->first;
+                        
+                        for (; it != array_map->end(); it ++) {
+			    BLOCK_TYPE *blk = it->second;
+                            if (blk->get_data() != NULL) {
+                                return it->first;
+                            }
+                        }
+			lru_list_.pop_back();
 		}
 		throw std::out_of_range("No blocks to remove !");
 		//sip::fail("No blocks to remove !", current_line());

--- a/src/sip/mpi/disk_backed_block_map.h
+++ b/src/sip/mpi/disk_backed_block_map.h
@@ -60,7 +60,10 @@ private:
 
 	//ServerBlock* get_or_create_block(const BlockId& block_id, size_t block_size, bool initialize);
 
-
+    long long block_access_counter;
+    long long disk_read_counter;
+    long long disk_write_counter;
+    long long total_stay_in_memory_counter;
 
     const SipTables &sip_tables_;
 	const SIPMPIAttr & sip_mpi_attr_;


### PR DESCRIPTION
LRU class only uses the first block of array in perarraymap for removal. It is possible that the data ptr of that block is null, so nothing is freed at all. This problem leads to an unchanged remaining_mem, and a dead loop. I modify the function so that it will return the first block with no null data ptr, or continue searching in other arrays.
