### PR TITLE
Dipole moment integral out of memory bug fix.  This should finish fixing...

### DIFF
--- a/src/sip/super_instructions/qm/compute_aabb_batch.F
+++ b/src/sip/super_instructions/qm/compute_aabb_batch.F
@@ -214,6 +214,8 @@ c     niscr = 5000000
 
       offset_1 = 0
       offset_2 = 0
+      offset_3 = 0
+      offset_4 = 0
       if (index_values_1(1).gt.1) offset_1=paosegs(index_values_1(1)-1)
       if (index_values_1(2).gt.1) offset_2=paosegs(index_values_1(2)-1)
       if (index_values_1(3).gt.1) offset_3=paosegs(index_values_1(3)-1)

--- a/src/sip/super_instructions/qm/compute_dipole_integrals.F
+++ b/src/sip/super_instructions/qm/compute_dipole_integrals.F
@@ -483,7 +483,7 @@ c-------------------------------------------------------------------------
       if (ixyz .eq. 1 .or. ixyz .eq. 10) then ! x NN moment 
          dnuc = 0.0 
          DO n = 1, natoms  
-            dnuc = dnuc + xn(m)*pcharge(m)  
+            dnuc = dnuc + xn(n)*pcharge(n)  
          ENDDO 
          if (ixyz .eq. 10) return 
       endif 
@@ -547,14 +547,14 @@ c ------------------------------------------------------------------------
 c Compute the xyz integrals. 
 c ------------------------------------------------------------------------ 
 
-              call oed__gener_xyz_batch(imax, zmax, nalpha, ncoeff,
-     *                 ncsum, ncfps(m), ncfps(n), npfps(m),npfps(n),
-     *                 ivangmom(m), ivangmom(n), x1,y1,z1,x2,y2,z2,
-     *                 alpha_pack,
-     *                 pcoeff_pack, ccbeg_pack, ccend_pack,
+              call oed__gener_xyz_batch(imax, zmax, 
+     *                 nalpha_pack, ncoeff_pack, ncsum, 
+     *                 ncfps(m), ncfps(n), npfps(m), npfps(n), 
+     *                 ivangmom(m), ivangmom(n), 
+     *                 x1,y1,z1,x2,y2,z2,
+     *                 alpha_pack, pcoeff_pack, ccbeg_pack, ccend_pack,
      *                 spherical, .false., iscr, ix, iy, iz, nints, 
-     *                 nfirst,
-     *                 zz)
+     *                 nfirst, zz)
 
                if (nints .gt. 0) then
 

--- a/src/sip/super_instructions/qm/compute_xyz_batch.F
+++ b/src/sip/super_instructions/qm/compute_xyz_batch.F
@@ -634,14 +634,14 @@ c ------------------------------------------------------------------------
 c Compute the xyz integrals. 
 c ------------------------------------------------------------------------ 
 
-              call oed__gener_xyz_batch(imax, zmax, nalpha, ncoeff,
-     *                 ncsum, ncfps(m), ncfps(n), npfps(m),npfps(n),
-     *                 ivangmom(m), ivangmom(n), x1,y1,z1,x2,y2,z2,
-     *                 alpha_pack,
-     *                 pcoeff_pack, ccbeg_pack, ccend_pack,
+              call oed__gener_xyz_batch(imax, zmax, 
+     *                 nalpha_pack, ncoeff_pack, ncsum, 
+     *                 ncfps(m), ncfps(n), npfps(m), npfps(n), 
+     *                 ivangmom(m), ivangmom(n), 
+     *                 x1,y1,z1,x2,y2,z2,
+     *                 alpha_pack, pcoeff_pack, ccbeg_pack, ccend_pack,
      *                 spherical, .false., iscr, ix, iy, iz, nints, 
-     *                 nfirst,
-     *                 zz)
+     *                 nfirst, zz)
 
                if (nints .gt. 0) then
 


### PR DESCRIPTION
... the

moment errors seen in the CIS tests.

uninitialized variable fix in aabb_batch

(cherry picked from commit e3078aec5c202e4388d5a33ad5ceafe85fe6d8c3)
