### PR TITLE
diis many write to block fix

### DIFF
--- a/src/sialx/qm/rccpt1p2_prop.sialx
+++ b/src/sialx/qm/rccpt1p2_prop.sialx
@@ -744,10 +744,10 @@
 	     if etemp == 1.0 
 		PUT Dai[a,i,k1diis] = tai[a,i] 
 	     endif 
+	  ENDDO k1diis  
 	     if n1 == one 
 		PREPARE D0ai[a,i] = tai[a,i] 
 	     endif 
-	  ENDDO k1diis  
       ENDDO kdiis 
       ENDPARDO a, i  
 

--- a/src/sialx/qm/rccsd_rhf.sialx
+++ b/src/sialx/qm/rccsd_rhf.sialx
@@ -2332,10 +2332,10 @@
 	     if etemp == 1.0 
 		PREPARE Daibj[a,i,b,j,k1diis] = taibj[a,i,b,j] 
 	     endif 
+	  ENDDO k1diis  
 	     if n1 == one 
 		PREPARE D0aibj[a,i,b,j] = taibj[a,i,b,j] 
 	     endif 
-	  ENDDO k1diis  
       ENDDO kdiis 
       ENDPARDO a, i, b, j 
 
@@ -2352,10 +2352,10 @@
 	     if etemp == 1.0 
 		PUT Dai[a,i,k1diis] = tai[a,i] 
 	     endif 
-	     if n1 == one 
-		PREPARE D0ai[a,i] = tai[a,i] 
-	     endif 
 	  ENDDO k1diis  
+	  if n1 == one 
+	     PREPARE D0ai[a,i] = tai[a,i] 
+	  endif 
       ENDDO kdiis 
       ENDPARDO a, i  
 

--- a/src/sialx/qm/rlambda_rhf.sialx
+++ b/src/sialx/qm/rlambda_rhf.sialx
@@ -3984,10 +3984,10 @@ import "rccsd_rhf_defs.sialx"
 	     if etemp == 1.0 
 		PREPARE Diajb[i,a,j,b,k1diis] = tiajb[i,a,j,b] 
 	     endif 
+	  ENDDO k1diis  
 	     if n1 == one 
 		PREPARE D0iajb[i,a,j,b] = tiajb[i,a,j,b] 
 	     endif 
-	  ENDDO k1diis  
       ENDDO kdiis 
       ENDPARDO a, i, b, j 
 
@@ -4004,10 +4004,10 @@ import "rccsd_rhf_defs.sialx"
 	     if etemp == 1.0 
 		PUT Dia[i,a,k1diis] = tia[i,a] 
 	     endif 
+	  ENDDO k1diis  
 	     if n1 == one 
 		PREPARE D0ia[i,a] = tia[i,a] 
 	     endif 
-	  ENDDO k1diis  
       ENDDO kdiis 
       ENDPARDO a, i  
 

--- a/src/sialx/qm/rlccd_rhf.sialx
+++ b/src/sialx/qm/rlccd_rhf.sialx
@@ -721,10 +721,10 @@ if kiter >= Idiis_order
 		if etemp == 1.0 
 		    PREPARE Daibj[a,i,b,j,k1diis] = taibj[a,i,b,j] 
 		endif 
+	    enddo k1diis  
 		if n1 == one 
 		    PREPARE D0aibj[a,i,b,j] = taibj[a,i,b,j] 
 		endif 
-	    enddo k1diis  
 	enddo kdiis 
     endpardo a, i, b, j 
 

--- a/src/sialx/qm/rlccsd_rhf.sialx
+++ b/src/sialx/qm/rlccsd_rhf.sialx
@@ -1262,10 +1262,10 @@
 	     if etemp == 1.0 
 		PREPARE Daibj[a,i,b,j,k1diis] = taibj[a,i,b,j] 
 	     endif 
+	  ENDDO k1diis  
 	     if n1 == one 
 		PREPARE D0aibj[a,i,b,j] = taibj[a,i,b,j] 
 	     endif 
-	  ENDDO k1diis  
       ENDDO kdiis 
       ENDPARDO a, i, b, j 
 
@@ -1282,10 +1282,10 @@
 	     if etemp == 1.0 
 		PUT Dai[a,i,k1diis] = tai[a,i] 
 	     endif 
+	  ENDDO k1diis  
 	     if n1 == one 
 		PREPARE D0ai[a,i] = tai[a,i] 
 	     endif 
-	  ENDDO k1diis  
       ENDDO kdiis 
       ENDPARDO a, i  
 


### PR DESCRIPTION
fixed the diis routine so that, when resetting histories, it would only set the 0 one once.