### PR TITLE
return diagonal unit matrix

### DIFF
--- a/src/sip/super_instructions/CMakeLists.txt
+++ b/src/sip/super_instructions/CMakeLists.txt
@@ -22,6 +22,7 @@ set(QM_SOURCE_FILES
     qm/qm-generic/energy_ty_denominator_rhf.F;
     qm/qm-generic/energy_denominator_rhf.F;
     qm/qm-generic/energy_numerator_rhf.F;
+    qm/utility/form_diagonal_unit_matrix.F;
     qm/utility/return_diagonal.F;
     qm/utility/print_block_and_index.F;
     qm/utility/inverse_lu_decomposition.F;

--- a/src/sip/super_instructions/Makefile.am
+++ b/src/sip/super_instructions/Makefile.am
@@ -45,6 +45,7 @@ QM_SOURCE_FILES=\
 ./qm/qm-generic/energy_ty_denominator_rhf.F\
 ./qm/qm-generic/energy_denominator_rhf.F\
 ./qm/qm-generic/energy_numerator_rhf.F\
+./qm/utility/form_diagonal_unit_matrix.F\
 ./qm/utility/return_diagonal.F\
 ./qm/utility/print_block_and_index.F\
 ./qm/utility/inverse_lu_decomposition.F\

--- a/src/sip/super_instructions/qm/direct_integral/compute_int_scratchmem.F
+++ b/src/sip/super_instructions/qm/direct_integral/compute_int_scratchmem.F
@@ -115,7 +115,7 @@ c ----------------------------------------------------------------------
       integer(C_INT):: nshells, ncenters, intSpherical  
       integer(C_INT):: one, two, m1, m2
       integer(C_INT):: my_imax, my_zmax 
-      logical(C_INT):: calc_2der, spherical 
+      logical:: calc_2der, spherical 
 
       integer i, nalphas, npcoeffs  
 

--- a/src/sip/super_instructions/qm/mcpt-fragment/compute_int_scratchmem_lowmem.F
+++ b/src/sip/super_instructions/qm/mcpt-fragment/compute_int_scratchmem_lowmem.F
@@ -97,7 +97,7 @@ c ----------------------------------------------------------------------
       integer(C_INT):: nshells, ncenters, intSpherical  
       integer(C_INT):: one, two, m1, m2
       integer(C_INT):: my_imax, my_zmax 
-      logical(C_INT):: calc_2der, spherical 
+      logical:: calc_2der, spherical 
 
       integer i, nalphas, npcoeffs  
 

--- a/src/sip/super_instructions/qm/mcpt-fragment/return_pairs.F
+++ b/src/sip/super_instructions/qm/mcpt-fragment/return_pairs.F
@@ -29,7 +29,7 @@ c--------------------------------------------------------------------------
       integer(C_INT), intent(in)::index_values_1(1:rank_1)
       integer(C_INT), intent(in)::size_1
       integer(C_INT), intent(in)::extents_1(1:rank_1)
-      real(C_DOUBLE), intent(out)::data_1(1:size_1) 
+      real(C_DOUBLE), intent(in)::data_1(1:size_1) 
 
 ! scalar array_2 --> fragment 2  
       integer(C_INT), intent(in)::array_2
@@ -37,7 +37,7 @@ c--------------------------------------------------------------------------
       integer(C_INT), intent(in)::index_values_2(1:rank_2)
       integer(C_INT), intent(in)::size_2
       integer(C_INT), intent(in)::extents_2(1:rank_2)
-      real(C_DOUBLE), intent(out)::data_2(1:size_2) 
+      real(C_DOUBLE), intent(in)::data_2(1:size_2) 
 
 ! scalar array_3 --> pair distance threshold  
       integer(C_INT), intent(in)::array_3
@@ -45,7 +45,7 @@ c--------------------------------------------------------------------------
       integer(C_INT), intent(in)::index_values_3(1:rank_3)
       integer(C_INT), intent(in)::size_3
       integer(C_INT), intent(in)::extents_3(1:rank_3)
-      real(C_DOUBLE), intent(out)::data_3(1:size_3) 
+      real(C_DOUBLE), intent(in)::data_3(1:size_3) 
 
 ! scalar array_4 --> indicator whether to perform pair cal or not   
       integer(C_INT), intent(in)::array_4
@@ -111,6 +111,8 @@ c  ATOMIC COORDINATES
       call return_dmin(ifrag,jfrag,nfrags,natoms_frag,watom_frag,
      *                 pcoords,r_thresh, data_4(1)) 
 
+
+      ierr = 0
       return
       end
 

--- a/src/sip/super_instructions/qm/utility/form_diagonal_unit_matrix.F
+++ b/src/sip/super_instructions/qm/utility/form_diagonal_unit_matrix.F
@@ -1,0 +1,63 @@
+! --------------------------------------------------------------------------
+!> @author Jason Byrd QTP
+!> @brief
+!> forms a diagonal unit matrix from a static array
+!>
+!> @details
+!>
+! --------------------------------------------------------------------------
+
+      subroutine form_diagonal_unit_matrix(
+     * array_0, rank_0, index_values_0, size_0, extents_0, data_0,
+     * ierr) BIND(C)
+      use, intrinsic :: ISO_C_BINDING
+      implicit none
+
+      include 'sip_interface.f'
+
+! output array --> array_0
+      integer(C_INT), intent(in)::array_0
+      integer(C_INT), intent(in)::rank_0
+      integer(C_INT), intent(in)::index_values_0(1:rank_0)
+      integer(C_INT), intent(in)::size_0
+      integer(C_INT), intent(in)::extents_0(1:rank_0)
+      real(C_DOUBLE), intent(out)::data_0(1:size_0)
+
+      integer(C_INT), intent(out)::ierr
+
+
+      if (rank_0 .eq. 2 .and. extents_0(1) .eq. extents_0(2)) then 
+
+      call form_diag2(1, extents_0(1),
+     *                1, extents_0(2),
+     *                data_0) 
+
+      else
+	  write(*,*) "ERROR: form_diagonal_unit_matrix 2 index only"
+	  call abort_job()
+      end if
+
+      ierr = 0
+
+      return 
+      end 
+
+      subroutine form_diag2(a1, a2, b1, b2, array)
+      
+      implicit none
+      integer a, a1, a2, b, b1, b2
+      integer m1, m2, n1, n2 
+      integer offset_1, offset_2 
+      double precision array(a1:a2,b1:b2), diag_sum  
+
+      do b = b1, b2 
+      do a = a1, a2 
+	  array(a,b) = 0.d0
+      enddo 
+          array(b,b) = 1.d0
+      enddo 
+
+
+      return
+      end
+

--- a/src/sip/super_instructions/special_instructions.cpp
+++ b/src/sip/super_instructions/special_instructions.cpp
@@ -326,6 +326,9 @@ void a4_dscale(
 void print_block_and_index(
         int& array_slot_0, int& rank_0, int * index_values_0, int& size_0, int * extents_0, double * data_0, int& ierr);
 
+void form_diagonal_unit_matrix(
+        int& array_slot_0, int& rank_0, int * index_values_0, int& size_0, int * extents_0, double * data_0, int& ierr);
+
 //##############################
 }
 
@@ -574,6 +577,7 @@ void SpecialInstructionManager::init_procmap(){
     procmap_["a4_scf_atom"]=(fp0)&a4_scf_atom;
     procmap_["a4_dscale"]=(fp0)&a4_dscale;
     procmap_["print_block_and_index"]=(fp0)&print_block_and_index;
+    procmap_["form_diagonal_unit_matrix"]=(fp0)&form_diagonal_unit_matrix;
 
 	//ADD STATEMENT TO ADD SPECIAL SUPERINSTRUCTION TO MAP HERE.  COPY ONE OF THE ABOVE LINES AND REPLACE THE
 	//CHARACTERS IN QUOTES WITH THE (CASE SENSITIVE NAME USED IN SIAL PROGRAMS.  REPLACE THE CHARACTERS FOLLOWING


### PR DESCRIPTION
added super instruction routine that takes on input a static (contiguous) array

then returns the unit diagonal.

updated a couple routines for fortran intent return warnings. far from comprehensive.